### PR TITLE
Refactor app package behind a test safety net

### DIFF
--- a/src/internal/apexapi/apexapi_test.go
+++ b/src/internal/apexapi/apexapi_test.go
@@ -1,0 +1,125 @@
+package apexapi
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// roundTripFunc lets a test act as the HTTP transport without a real network.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func newStubClient(fn roundTripFunc) *http.Client {
+	return &http.Client{Transport: fn, Timeout: 5 * time.Second}
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+const sampleResponse = `{
+  "battle_royale": {
+    "current": {"start": 1000, "end": 2000, "map": "World's Edge", "code": "we", "asset": "https://example.com/we.png", "ignored": "x"},
+    "next":    {"start": 2000, "end": 3000, "map": "Olympus", "code": "ol", "asset": "https://example.com/ol.png"}
+  },
+  "ranked": {
+    "current": {"start": 1100, "end": 2100, "map": "Storm Point", "code": "sp", "asset": ""},
+    "next":    {"start": 2100, "end": 3100, "map": "Broken Moon", "code": "bm", "asset": ""}
+  },
+  "ltm": {
+    "current": {"start": 1200, "end": 2200, "map": "Kings Canyon", "code": "kc", "asset": ""},
+    "next":    {"start": 2200, "end": 3200, "map": "Fragment", "code": "fr", "asset": ""}
+  }
+}`
+
+func TestUpdateParsesResponse(t *testing.T) {
+	var gotURL *url.URL
+	SetClient(newStubClient(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL
+		return jsonResponse(http.StatusOK, sampleResponse), nil
+	}))
+	t.Cleanup(func() { SetClient(nil) })
+
+	var m Modes
+	if err := m.Update("secret-key"); err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+
+	// Endpoint and required query params.
+	if gotURL.Host != "api.mozambiquehe.re" || gotURL.Path != "/maprotation" {
+		t.Errorf("unexpected endpoint: %s", gotURL)
+	}
+	if got := gotURL.Query().Get("auth"); got != "secret-key" {
+		t.Errorf("auth query = %q, want %q", got, "secret-key")
+	}
+	if got := gotURL.Query().Get("version"); got != "2" {
+		t.Errorf("version query = %q, want %q", got, "2")
+	}
+
+	// Battle royale (Pub) mapping.
+	if m.Pub.Current.Map != "World's Edge" || m.Pub.Current.Start != 1000 || m.Pub.Current.End != 2000 {
+		t.Errorf("Pub.Current mismatch: %+v", m.Pub.Current)
+	}
+	if m.Pub.Current.Asset != "https://example.com/we.png" {
+		t.Errorf("Pub.Current.Asset = %q", m.Pub.Current.Asset)
+	}
+	if m.Pub.Next.Map != "Olympus" {
+		t.Errorf("Pub.Next.Map = %q", m.Pub.Next.Map)
+	}
+
+	// Ranked and Ltm mapping.
+	if m.Ranked.Current.Map != "Storm Point" || m.Ranked.Next.Map != "Broken Moon" {
+		t.Errorf("Ranked mismatch: %+v", m.Ranked)
+	}
+	if m.Ltm.Current.Map != "Kings Canyon" || m.Ltm.Next.Map != "Fragment" {
+		t.Errorf("Ltm mismatch: %+v", m.Ltm)
+	}
+}
+
+func TestUpdateInvalidJSON(t *testing.T) {
+	SetClient(newStubClient(func(req *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, "not json"), nil
+	}))
+	t.Cleanup(func() { SetClient(nil) })
+
+	var m Modes
+	err := m.Update("k")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	// The error is expected to include the raw body for debuggability.
+	if !strings.Contains(err.Error(), "not json") {
+		t.Errorf("error should contain raw body, got: %v", err)
+	}
+}
+
+func TestUpdateTransportError(t *testing.T) {
+	SetClient(newStubClient(func(req *http.Request) (*http.Response, error) {
+		return nil, io.ErrUnexpectedEOF
+	}))
+	t.Cleanup(func() { SetClient(nil) })
+
+	var m Modes
+	if err := m.Update("k"); err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+}
+
+func TestSetClientNilResetsToDefault(t *testing.T) {
+	SetClient(nil)
+	if client == nil {
+		t.Fatal("SetClient(nil) must leave a usable client")
+	}
+	if client.Timeout != 30*time.Second {
+		t.Errorf("default client timeout = %v, want 30s", client.Timeout)
+	}
+}

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -20,7 +19,7 @@ import (
 	"package/main/internal/apexapi"
 )
 
-var modes apexapi.Modes
+var store modesStore
 
 var ctx, cancel = context.WithCancel(context.Background())
 var group, groupCtx = errgroup.WithContext(ctx)
@@ -63,6 +62,13 @@ func getExternalIP(httpClient *http.Client) (string, error) {
 // Run func is similar to the main func.
 func Run() {
 
+	conf, err := loadConfig()
+	if err != nil {
+		fmt.Printf("Something went wrong while reading the configuration: %s", err)
+		os.Exit(1)
+	}
+	configureLogger(conf)
+
 	log.Info("Starting app")
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	httpClient := &http.Client{Timeout: defaultHTTPTimeout, Transport: transport}
@@ -102,17 +108,24 @@ func Run() {
 	})
 
 	group.Go(func() error {
-		if err := modes.Update(conf.ApexAPIKey); err != nil {
-			log.Error(err) // shit
-		} // get on start and then every interval seconds
-		interval := 120 // sec
-		ticker := time.NewTicker(time.Duration(interval) * time.Second)
+		// refresh fetches a fresh rotation without holding the store lock during
+		// network I/O, then atomically swaps it in.
+		refresh := func() {
+			var fresh apexapi.Modes
+			if err := fresh.Update(conf.ApexAPIKey); err != nil {
+				log.Errorf("Failed to update map rotation: %v", err)
+				return
+			}
+			store.set(fresh)
+		}
+
+		refresh() // get on start and then every UpdateInterval
+		ticker := time.NewTicker(conf.UpdateInterval)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				if err := modes.Update(conf.ApexAPIKey); err != nil {
-					log.Error(err)
-				}
+				refresh()
 			case <-groupCtx.Done():
 				log.Error("Closing apexmaps modes goroutine")
 				return groupCtx.Err()
@@ -121,7 +134,6 @@ func Run() {
 	})
 
 	bot, err := tgbotapi.NewBotAPIWithClient(conf.BotAPIKey, tgbotapi.APIEndpoint, tgHTTPClient)
-	md2regex := regexp.MustCompile(`(\_|\*|\[|\]|\(|\)|\~|\>|\#|\+|\-|\=|\||\{|\}|\.|\!)`)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -145,60 +157,26 @@ func Run() {
 
 				msg := tgbotapi.NewMessage(update.Message.Chat.ID, "")
 
-				switch update.Message.Command() {
+				command := update.Message.Command()
+				switch command {
 				case "help":
 					msg.Text = "I understand /map /ranked /ltm"
 				case "map":
-					now := time.Now()
-					nextStartAt := time.Unix(modes.Pub.Next.Start, 0)
-					nextEndAt := time.Unix(modes.Pub.Next.End, 0)
-					nextDiff := nextStartAt.Sub(now)
-					nextLasts := nextEndAt.Sub(nextStartAt)
-					msg.Text = fmt.Sprintf("Карта сейчас *%s* и продлится *%dч %dм*\nСледующая карта *%s* и продлится *%dч %dм*\n[](%s)",
-						md2regex.ReplaceAllString(modes.Pub.Current.Map, `\$1`),
-						int(nextDiff.Hours()),
-						int(nextDiff.Minutes())-int(nextDiff.Hours())*60, md2regex.ReplaceAllString(modes.Pub.Next.Map, `\$1`),
-						int(nextLasts.Hours()),
-						int(nextLasts.Minutes())-int(nextLasts.Hours())*60,
-						modes.Pub.Current.Asset,
-					)
-					msg.ReplyToMessageID = update.Message.MessageID
-					msg.ParseMode = "MarkdownV2"
-					log.Infof("Recived new message from user %s, chat ID %d", update.Message.From, update.Message.Chat.ID)
+					msg.Text = formatMode("", store.get().Pub, time.Now(), true)
 				case "ranked":
-					now := time.Now()
-					nextStartAt := time.Unix(modes.Ranked.Next.Start, 0)
-					nextEndAt := time.Unix(modes.Ranked.Next.End, 0)
-					nextDiff := nextStartAt.Sub(now)
-					nextLasts := nextEndAt.Sub(nextStartAt)
-					msg.Text = fmt.Sprintf("Карта в рейтинге сейчас *%s* и продлится *%dч %dм*\nСледующая карта *%s* и продлится *%dч %dм*",
-						md2regex.ReplaceAllString(modes.Ranked.Current.Map, `\$1`),
-						int(nextDiff.Hours()),
-						int(nextDiff.Minutes())-int(nextDiff.Hours())*60, md2regex.ReplaceAllString(modes.Ranked.Next.Map, `\$1`),
-						int(nextLasts.Hours()),
-						int(nextLasts.Minutes())-int(nextLasts.Hours())*60,
-					)
-					msg.ReplyToMessageID = update.Message.MessageID
-					msg.ParseMode = "MarkdownV2"
-					log.Infof("Recived new message from user %s, chat ID %d", update.Message.From, update.Message.Chat.ID)
+					msg.Text = formatMode("в рейтинге ", store.get().Ranked, time.Now(), false)
 				case "ltm":
-					now := time.Now()
-					nextStartAt := time.Unix(modes.Ltm.Next.Start, 0)
-					nextEndAt := time.Unix(modes.Ltm.Next.End, 0)
-					nextDiff := nextStartAt.Sub(now)
-					nextLasts := nextEndAt.Sub(nextStartAt)
-					msg.Text = fmt.Sprintf("Карта в ltm сейчас *%s* и продлится *%dч %dм*\nСледующая карта *%s* и продлится *%dч %dм*",
-						md2regex.ReplaceAllString(modes.Ltm.Current.Map, `\$1`),
-						int(nextDiff.Hours()),
-						int(nextDiff.Minutes())-int(nextDiff.Hours())*60, md2regex.ReplaceAllString(modes.Ltm.Next.Map, `\$1`),
-						int(nextLasts.Hours()),
-						int(nextLasts.Minutes())-int(nextLasts.Hours())*60,
-					)
-					msg.ReplyToMessageID = update.Message.MessageID
-					msg.ParseMode = "MarkdownV2"
-					log.Infof("Recived new message from user %s, chat ID %d", update.Message.From, update.Message.Chat.ID)
+					msg.Text = formatMode("в ltm ", store.get().Ltm, time.Now(), false)
 				default:
 					msg.Text = "I don't know that command, use /help"
+				}
+
+				// The map/ranked/ltm replies are formatted MarkdownV2 answers to
+				// the triggering message; help/unknown are plain replies.
+				if command == "map" || command == "ranked" || command == "ltm" {
+					msg.ReplyToMessageID = update.Message.MessageID
+					msg.ParseMode = "MarkdownV2"
+					log.Infof("Recived new message from user %s, chat ID %d", update.Message.From, update.Message.Chat.ID)
 				}
 				if _, err := bot.Send(msg); err != nil {
 					log.Error(err)

--- a/src/internal/app/config.go
+++ b/src/internal/app/config.go
@@ -2,26 +2,26 @@ package app
 
 import (
 	"fmt"
-	"os"
+	"time"
 
 	"github.com/ilyakaznacheev/cleanenv"
 )
 
 // Config is the main configuration structure of this application
 type Config struct {
-	ApexAPIKey string `env:"APEX_API_KEY"    env-required:"true"`
-	Loglevel   string `env:"LOG_LEVEL"       env-default:"error"`
-	BotDebug   bool   `env:"TGBOT_DEBUG"     env-default:"false"`
-	BotAPIKey  string `env:"TGBOT_API_KEY"   env-required:"true"`
-	HTTPProxy  string `env:"HTTP_PROXY"      env-default:""`
+	ApexAPIKey     string        `env:"APEX_API_KEY"    env-required:"true"`
+	Loglevel       string        `env:"LOG_LEVEL"       env-default:"error"`
+	BotDebug       bool          `env:"TGBOT_DEBUG"     env-default:"false"`
+	BotAPIKey      string        `env:"TGBOT_API_KEY"   env-required:"true"`
+	HTTPProxy      string        `env:"HTTP_PROXY"      env-default:""`
+	UpdateInterval time.Duration `env:"UPDATE_INTERVAL" env-default:"120s"`
 }
 
-var conf Config
-
-func init() {
-	err := cleanenv.ReadEnv(&conf)
-	if err != nil {
-		fmt.Printf("Something went wrong while reading the configuration: %s", err)
-		os.Exit(1)
+// loadConfig reads the configuration from environment variables.
+func loadConfig() (Config, error) {
+	var c Config
+	if err := cleanenv.ReadEnv(&c); err != nil {
+		return Config{}, fmt.Errorf("reading configuration: %w", err)
 	}
+	return c, nil
 }

--- a/src/internal/app/format.go
+++ b/src/internal/app/format.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"package/main/internal/apexapi"
+)
+
+// md2regex matches every character that must be escaped in Telegram MarkdownV2.
+var md2regex = regexp.MustCompile(`(\_|\*|\[|\]|\(|\)|\~|\>|\#|\+|\-|\=|\||\{|\}|\.|\!)`)
+
+// escapeMarkdownV2 escapes reserved MarkdownV2 characters in s.
+func escapeMarkdownV2(s string) string {
+	return md2regex.ReplaceAllString(s, `\$1`)
+}
+
+// hoursAndMinutes splits a duration into whole hours and the remaining minutes.
+func hoursAndMinutes(d time.Duration) (hours, minutes int) {
+	hours = int(d.Hours())
+	minutes = int(d.Minutes()) - hours*60
+	return hours, minutes
+}
+
+// formatMode renders the notification text for a single game mode.
+//
+// prefix is inserted between "Карта " and "сейчас" ("" for battle royale,
+// "в рейтинге " for ranked, "в ltm " for ltm). When withAsset is true the
+// current map asset link is appended on its own line.
+func formatMode(prefix string, maps apexapi.Maps, now time.Time, withAsset bool) string {
+	nextStartAt := time.Unix(maps.Next.Start, 0)
+	nextEndAt := time.Unix(maps.Next.End, 0)
+
+	currentHours, currentMinutes := hoursAndMinutes(nextStartAt.Sub(now))
+	nextHours, nextMinutes := hoursAndMinutes(nextEndAt.Sub(nextStartAt))
+
+	text := fmt.Sprintf(
+		"Карта %sсейчас *%s* и продлится *%dч %dм*\nСледующая карта *%s* и продлится *%dч %dм*",
+		prefix,
+		escapeMarkdownV2(maps.Current.Map),
+		currentHours, currentMinutes,
+		escapeMarkdownV2(maps.Next.Map),
+		nextHours, nextMinutes,
+	)
+
+	if withAsset {
+		text += fmt.Sprintf("\n[](%s)", maps.Current.Asset)
+	}
+
+	return text
+}

--- a/src/internal/app/format_test.go
+++ b/src/internal/app/format_test.go
@@ -1,0 +1,83 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"package/main/internal/apexapi"
+)
+
+func TestEscapeMarkdownV2(t *testing.T) {
+	cases := map[string]string{
+		"World's Edge":      "World's Edge",                       // apostrophe is not reserved
+		"E-District":        `E\-District`,                        // hyphen is reserved
+		"a.b":               `a\.b`,                               // dot
+		"x!y":               `x\!y`,                               // bang
+		`_*[]()~>#+-=|{}.!`: `\_\*\[\]\(\)\~\>\#\+\-\=\|\{\}\.\!`, // full reserved set
+	}
+	for in, want := range cases {
+		if got := escapeMarkdownV2(in); got != want {
+			t.Errorf("escapeMarkdownV2(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHoursAndMinutes(t *testing.T) {
+	cases := []struct {
+		d     time.Duration
+		wantH int
+		wantM int
+	}{
+		{90 * time.Minute, 1, 30},
+		{135 * time.Minute, 2, 15},
+		{0, 0, 0},
+		{59 * time.Minute, 0, 59},
+	}
+	for _, c := range cases {
+		h, m := hoursAndMinutes(c.d)
+		if h != c.wantH || m != c.wantM {
+			t.Errorf("hoursAndMinutes(%v) = %dh %dm, want %dh %dm", c.d, h, m, c.wantH, c.wantM)
+		}
+	}
+}
+
+// fixtureMaps returns a Maps value with a clean 1h30m gap until the next map
+// and a 2h15m next-map duration, relative to the returned "now".
+func fixtureMaps(currentMap, nextMap, asset string) (apexapi.Maps, time.Time) {
+	now := time.Unix(1000, 0)
+	nextStart := int64(1000 + 90*60)     // now + 1h30m
+	nextEnd := nextStart + int64(135*60) // + 2h15m
+	m := apexapi.Maps{
+		Current: apexapi.Map{Start: 0, End: nextStart, Map: currentMap, Asset: asset},
+		Next:    apexapi.Map{Start: nextStart, End: nextEnd, Map: nextMap},
+	}
+	return m, now
+}
+
+func TestFormatModeBattleRoyale(t *testing.T) {
+	m, now := fixtureMaps("E-District", "Olympus", "https://example.com/we.png")
+	want := "Карта сейчас *E\\-District* и продлится *1ч 30м*\n" +
+		"Следующая карта *Olympus* и продлится *2ч 15м*\n" +
+		"[](https://example.com/we.png)"
+	if got := formatMode("", m, now, true); got != want {
+		t.Errorf("formatMode battle royale:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestFormatModeRanked(t *testing.T) {
+	m, now := fixtureMaps("E-District", "Olympus", "ignored")
+	want := "Карта в рейтинге сейчас *E\\-District* и продлится *1ч 30м*\n" +
+		"Следующая карта *Olympus* и продлится *2ч 15м*"
+	if got := formatMode("в рейтинге ", m, now, false); got != want {
+		t.Errorf("formatMode ranked:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestFormatModeLtm(t *testing.T) {
+	m, now := fixtureMaps("E-District", "Olympus", "ignored")
+	want := "Карта в ltm сейчас *E\\-District* и продлится *1ч 30м*\n" +
+		"Следующая карта *Olympus* и продлится *2ч 15м*"
+	if got := formatMode("в ltm ", m, now, false); got != want {
+		t.Errorf("formatMode ltm:\n got: %q\nwant: %q", got, want)
+	}
+}

--- a/src/internal/app/logger.go
+++ b/src/internal/app/logger.go
@@ -6,20 +6,23 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log *logrus.Logger
+// log is usable before configuration (default logrus settings) so that any
+// code path — including tests — can log without an explicit setup step.
+var log = logrus.New()
 
-func init() {
-	log = logrus.New()
+// configureLogger applies the JSON formatter, stdout output and the configured
+// log level to the global logger.
+func configureLogger(cfg Config) {
 	log.SetFormatter(&logrus.JSONFormatter{})
 	log.SetOutput(os.Stdout)
 
-	loglevel, err := logrus.ParseLevel(conf.Loglevel)
-	if err == nil {
-		log.SetLevel(loglevel)
-	} else {
+	level, err := logrus.ParseLevel(cfg.Loglevel)
+	if err != nil {
 		log.SetLevel(logrus.ErrorLevel)
 		log.Error("Can`t parse LOG_LEVEL. Used default value: LOG_LEVEL=error")
+	} else {
+		log.SetLevel(level)
 	}
 
-	log.Infof("Used json logger and loglevel: %s", conf.Loglevel)
+	log.Infof("Used json logger and loglevel: %s", cfg.Loglevel)
 }

--- a/src/internal/app/store.go
+++ b/src/internal/app/store.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	"sync"
+
+	"package/main/internal/apexapi"
+)
+
+// modesStore holds the latest map rotation and guards it against concurrent
+// access by the updater goroutine (writer) and the Telegram handler (reader).
+type modesStore struct {
+	mu   sync.RWMutex
+	data apexapi.Modes
+}
+
+// set atomically replaces the stored rotation.
+func (s *modesStore) set(m apexapi.Modes) {
+	s.mu.Lock()
+	s.data = m
+	s.mu.Unlock()
+}
+
+// get returns a snapshot of the stored rotation. apexapi.Modes is a plain value
+// struct, so the returned copy is safe to read without further locking.
+func (s *modesStore) get() apexapi.Modes {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.data
+}

--- a/src/internal/app/store_test.go
+++ b/src/internal/app/store_test.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"sync"
+	"testing"
+
+	"package/main/internal/apexapi"
+)
+
+func TestModesStoreSetGet(t *testing.T) {
+	var s modesStore
+	if got := s.get().Pub.Current.Map; got != "" {
+		t.Errorf("zero-value store should return empty map, got %q", got)
+	}
+
+	s.set(apexapi.Modes{Pub: apexapi.Maps{Current: apexapi.Map{Map: "Olympus"}}})
+	if got := s.get().Pub.Current.Map; got != "Olympus" {
+		t.Errorf("get after set = %q, want %q", got, "Olympus")
+	}
+}
+
+// TestModesStoreConcurrent must be run with -race to be meaningful: it exercises
+// concurrent writers and readers to prove the store is data-race free.
+func TestModesStoreConcurrent(t *testing.T) {
+	var s modesStore
+	var wg sync.WaitGroup
+
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			s.set(apexapi.Modes{Pub: apexapi.Maps{Current: apexapi.Map{Map: "World's Edge"}}})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = s.get().Pub.Current.Map
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Что и зачем

Рефакторинг пакета `app` с сохранением бизнес-функционала. Подход: сначала «золотая сеть» characterization-тестов, фиксирующая текущее поведение, затем рефакторинг под ней.

## Тесты (сеть)

- **apexapi** — парсинг ответа API, проверка query-параметров `auth`/`version` и эндпоинта, обработка невалидного JSON и ошибки транспорта. Подмена HTTP через существующий `SetClient`, без сети.
- **app (format)** — golden-тесты, фиксирующие точный вывод сообщений MarkdownV2 (`/map`, `/ranked`, `/ltm`), включая экранирование.
- **store** — конкурентный `set`/`get` под `-race`, подтверждающий отсутствие гонки.

## Рефакторинг

- **config/logger из `init()` → явные функции.** `loadConfig()` и `configureLogger()` вызываются в `Run()`; убран `os.Exit` из пакетного `init` — это делает пакет `app` тестируемым. Падение при отсутствии обязательных env сохранено при реальном старте.
- **Fix data race.** Общий `modes` заменён на потокобезопасный `modesStore` (`RWMutex`). Сетевой I/O идёт вне лока (fetch во временную переменную → атомарный swap), читатель берёт снапшот.
- **Дедуп.** Три почти идентичных обработчика `map`/`ranked`/`ltm` (~45 строк) свёрнуты в `formatMode()`.
- **Интервал в конфиг.** `UPDATE_INTERVAL` (дефолт `120s`, поведение сохранено), добавлен `ticker.Stop()` при завершении.

## Проверки

```
go build ./...        OK
go vet ./...          OK
go test -race ./...   OK
gofmt -l internal/    чисто
staticcheck ./...     чисто
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)